### PR TITLE
explicitly destroying io_serv at the end of shutdown

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -164,6 +164,7 @@ void application::shutdown() {
    running_plugins.clear();
    initialized_plugins.clear();
    plugins.clear();
+   io_serv.reset();
 }
 
 void application::quit() {


### PR DESCRIPTION
when the io_serv is stopped it may still own std::functions/lambdas that have captured data in them.  If this captured data relies on another system like a logging system, for instance, waiting for destructors to be called by the atexit call may result in them accessing a destroyed system.  By explicitly resetting the io_serve after shutdown we in turn release any resources it has while the systems are still alive and well