### PR TITLE
Fix boost library link ordering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 SET(BOOST_COMPONENTS)
 LIST(APPEND BOOST_COMPONENTS thread
                              date_time
-                             system
                              filesystem
+                             system
                              chrono
                              program_options
                              unit_test_framework


### PR DESCRIPTION
boost filesystem uses boost system. Set the link order accordingly. Fixes boost 1.66 linkage on Linux with ld.