### PR TITLE
Add independent config directory and let users set default dirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,15 @@
 project( AppBase )
 cmake_minimum_required( VERSION 2.8.12 )
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+
+include( InstallDirectoryPermissions )
+
 file(GLOB HEADERS "include/appbase/*.hpp")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
-SET(BOOST_COMPONENTS)
-LIST(APPEND BOOST_COMPONENTS thread
+set(BOOST_COMPONENTS)
+list(APPEND BOOST_COMPONENTS thread
                              date_time
                              filesystem
                              system
@@ -15,7 +19,7 @@ LIST(APPEND BOOST_COMPONENTS thread
                              unit_test_framework
                              locale)
 
-FIND_PACKAGE(Boost 1.60 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
+find_package(Boost 1.60 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 
 if( APPLE )
@@ -48,13 +52,18 @@ target_link_libraries( appbase ${Boost_LIBRARIES})
 target_include_directories( appbase
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR})
 
-INSTALL( TARGETS
+set_target_properties( appbase PROPERTIES PUBLIC_HEADER "${HEADERS}" )
+
+set(CPACK_PACKAGING_INSTALL_PREFIX /)
+
+install( TARGETS
    appbase
 
-   RUNTIME DESTINATION bin
-   LIBRARY DESTINATION lib
-   ARCHIVE DESTINATION lib
+   RUNTIME DESTINATION usr/bin
+   LIBRARY DESTINATION usr/lib
+   ARCHIVE DESTINATION usr/lib
+   PUBLIC_HEADER DESTINATION usr/include/appbase
 )
-INSTALL( FILES ${HEADERS} DESTINATION "include/appbase" )
+install_directory_permissions( DIRECTORY usr/include/appbase )
 
 add_subdirectory( examples )

--- a/CMakeModules/InstallDirectoryPermissions.cmake
+++ b/CMakeModules/InstallDirectoryPermissions.cmake
@@ -1,0 +1,14 @@
+# Fix directory permissions after installation of header files (primarily).
+macro(install_directory_permissions)
+  cmake_parse_arguments(ARG "" "DIRECTORY" "" ${ARGN})
+  set(dir ${ARG_DIRECTORY})
+  install(DIRECTORY DESTINATION ${dir}
+          DIRECTORY_PERMISSIONS OWNER_READ
+                                OWNER_WRITE
+                                OWNER_EXECUTE
+                                GROUP_READ
+                                GROUP_EXECUTE
+                                WORLD_READ
+                                WORLD_EXECUTE
+  )
+endmacro(install_directory_permissions)

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -23,6 +23,28 @@ namespace appbase {
           * @return Version output with -v/--version
           */
          uint64_t version() const;
+         /** @brief Set default data directory
+          *
+          * @param data_dir Default data directory to use if not specified
+          *                 on the command line.
+          */
+         void set_default_data_dir(const bfs::path& data_dir = "data-dir");
+         /** @brief Get data directory
+          *
+          * @return Data directory, possibly from command line
+          */
+         bfs::path data_dir() const;
+         /** @brief Set default config directory
+          *
+          * @param config_dir Default configuration directory to use if not
+          *                   specified on the command line.
+          */
+         void set_default_config_dir(const bfs::path& config_dir = "etc");
+         /** @brief Get config directory
+          *
+          * @return Config directory, possibly from command line
+          */
+         bfs::path config_dir() const;
          /** @brief Get logging configuration path.
           *
           * @return Logging configuration location from command line
@@ -77,9 +99,6 @@ namespace appbase {
             auto ptr = find_plugin<Plugin>();
             return *ptr;
          }
-
-         bfs::path data_dir()const;
-
 
          boost::asio::io_service& get_io_service() { return *io_serv; }
       protected:


### PR DESCRIPTION
Use standard endline.
Regularize capitalization of CMake directives.
Revise CMake installation with an eye toward more modern versions of CMake.
Set explicit installation directory permissions so it works regardless of user's umask.