### PR TITLE
When a plugin throws during startup, cleanup

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -57,8 +57,13 @@ bfs::path application::get_logging_conf() const {
 }
 
 void application::startup() {
-   for (auto plugin : initialized_plugins)
-      plugin->startup();
+   try {
+      for (auto plugin : initialized_plugins)
+         plugin->startup();
+   } catch(...) {
+      shutdown();
+      throw;
+   }
 }
 
 application& application::instance() {


### PR DESCRIPTION
Some of our plugins will throw an exception on startup. For example, the http or net plugin will throw if it can’t bind to an address. Exceptions thrown at this stage are uncaught and cause the process to exit.

However, in the process of unwinding the stack to exit, application’s dtor will call all of the already started plugins dtors. Some of these plugins don’t handle the case where their dtor is called without shtudown() being called on the plugin first. Result can be a (benign, but still embarrassing) crash on exit.

Change appbase so that any exception thrown during startup() is caught, then all plugins shutdown, then exception is rethrown so that the app continues to exit.