### PR TITLE
Add option to print default configuration template

### DIFF
--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -124,6 +124,7 @@ namespace appbase {
 
          void set_program_options();
          void write_default_config(const bfs::path& cfg_file);
+         void print_default_config(std::ostream& os);
          std::unique_ptr<class application_impl> my;
 
    };


### PR DESCRIPTION
Add an option to print the default configuration template. This could be useful to packagers (to create an /etc/ template without making /etc writable) or for users to see a diff of their config.ini compared to future defaults (for example `diff -u <(nodeos --print-default-config) config.ini`).