### PR TITLE
add channels and methods

### DIFF
--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -102,6 +102,13 @@ namespace appbase {
             return *ptr;
          }
 
+         /**
+          * Fetch a reference to the method declared by the passed in type.  This will construct the method
+          * on first access.  This allows loose and deferred binding between plugins
+          *
+          * @tparam MethodDecl - @ref appbase::method_decl
+          * @return reference to the method described by the declaration
+          */
          template<typename MethodDecl>
          auto get_method() -> std::enable_if_t<is_method_decl<MethodDecl>::value, typename MethodDecl::method_type&>
          {
@@ -116,6 +123,13 @@ namespace appbase {
             }
          }
 
+         /**
+          * Fetch a reference to the channel declared by the passed in type.  This will construct the channel
+          * on first access.  This allows loose and deferred binding between plugins
+          *
+          * @tparam ChannelDecl - @ref appbase::channel_decl
+          * @return reference to the channel described by the declaration
+          */
          template<typename ChannelDecl>
          auto get_channel() -> std::enable_if_t<is_channel_decl<ChannelDecl>::value, typename ChannelDecl::channel_type&>
          {

--- a/include/appbase/channel.hpp
+++ b/include/appbase/channel.hpp
@@ -44,6 +44,7 @@ namespace appbase {
       public:
          using ios_ptr_type = std::shared_ptr<boost::asio::io_service>;
          using handle_type = boost::signals2::connection;
+         using scoped_handle_type = boost::signals2::scoped_connection;
 
          /**
           * Publish data to a channel

--- a/include/appbase/channel.hpp
+++ b/include/appbase/channel.hpp
@@ -56,6 +56,14 @@ namespace appbase {
                   }
                }
 
+               handle() = default;
+               handle(handle&&) = default;
+               handle& operator= (handle&& rhs) = default;
+
+               // dont allow copying since this protects the resource
+               handle(const handle& ) = delete;
+               handle& operator= (const handle& ) = delete;
+
             private:
                using handle_type = boost::signals2::connection;
                handle_type _handle;
@@ -108,7 +116,8 @@ namespace appbase {
           * Returns whether or not there are subscribers
           */
          bool has_subscribers() {
-            return _signal.num_slots() > 0;
+            auto connections = _signal.num_slots();
+            return connections > 0;
          }
 
       private:

--- a/include/appbase/channel.hpp
+++ b/include/appbase/channel.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+//clashes with BOOST PP and Some Applications
+#pragma push_macro("N")
+#undef N
+
+#include <boost/asio.hpp>
+#include <boost/signals2.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace appbase {
+
+   using erased_channel_ptr = std::unique_ptr<void, void(*)(void*)>;
+
+   struct drop_exceptions {
+      drop_exceptions() = default;
+      using result_type = void;
+
+      template<typename InputIterator>
+      result_type operator()(InputIterator first, InputIterator last) {
+         while (first != last) {
+            try {
+               *first;
+            } catch (...) {
+               // drop
+            }
+            ++first;
+         }
+      }
+   };
+
+   /**
+    * A channel is a loosely bound asynchronous data pub/sub concept.
+    *
+    * This removes the need to tightly couple different plugins in the application for the use-case of
+    * sending data around
+    *
+    * Data passed to a channel is *copied*, consider using a shared_ptr if the use-case allows it
+    *
+    * @tparam Data - the type of data to publish
+    */
+   template<typename Data, typename DispatchPolicy>
+   class channel final : private boost::signals2::signal<void(const Data&), DispatchPolicy> {
+      public:
+         using ios_ptr_type = std::shared_ptr<boost::asio::io_service>;
+         using handle_type = boost::signals2::connection;
+
+         /**
+          * Publish data to a channel
+          * @param data
+          */
+         void publish(const Data& data) {
+            if (has_subscribers()) {
+               // this will copy data into the lambda
+               ios_ptr->post([this, data]() {
+                  (*this)(data);
+               });
+            }
+         }
+
+         /**
+          * subscribe to data on a channel
+          * @tparam Callback the type of the callback (functor|lambda)
+          * @param cb the callback
+          * @return handle to the subscription
+          */
+         template<typename Callback>
+         handle_type subscribe(Callback cb) {
+            return this->connect(cb);
+         }
+
+         /**
+          * unsubscribe from data on a channel
+          * @param handle
+          */
+         void unsubscribe(const handle_type& handle) {
+            handle.disconnect();
+         }
+
+         /**
+          * set the dispatcher according to the DispatchPolicy
+          * this can be used to set a stateful dispatcher
+          *
+          * This method is only available when the DispatchPolicy is copy constructible due to implementation details
+          *
+          * @param policy - the DispatchPolicy to copy
+          */
+         auto set_dispatcher(const DispatchPolicy& policy ) -> std::enable_if_t<std::is_copy_constructible<DispatchPolicy>::value,void>
+         {
+            (*this).set_combiner(policy);
+         }
+
+         /**
+          * Returns whether or not there are subscribers
+          */
+         bool has_subscribers() {
+            return (*this).num_slots() > 0;
+         }
+
+      private:
+         channel(const ios_ptr_type& ios_ptr)
+         :ios_ptr(ios_ptr)
+         {
+         }
+
+         virtual ~channel() {};
+
+         /**
+          * Proper deleter for type-erased channel
+          * note: no type checking is performed at this level
+          *
+          * @param erased_channel_ptr
+          */
+         static void deleter(void* erased_channel_ptr) {
+            channel *ptr = reinterpret_cast<channel*>(erased_channel_ptr);
+            delete ptr;
+         }
+
+         /**
+          * get the channel back from an erased pointer
+          *
+          * @param ptr - the type-erased channel pointer
+          * @return - the type safe channel pointer
+          */
+         static channel* get_channel(erased_channel_ptr& ptr) {
+            return reinterpret_cast<channel*>(ptr.get());
+         }
+
+         /**
+          * Construct a unique_ptr for the type erased method poiner
+          * @return
+          */
+         static erased_channel_ptr make_unique(const ios_ptr_type& ios_ptr)
+         {
+            return erased_channel_ptr(new channel(ios_ptr), &deleter);
+         }
+
+         ios_ptr_type ios_ptr;
+
+         friend class appbase::application;
+   };
+
+   template< typename Tag, typename Data, typename DispatchPolicy = drop_exceptions >
+   struct channel_decl {
+      using channel_type = channel<Data, DispatchPolicy>;
+      using tag_type = Tag;
+   };
+
+   template <typename...Ts>
+   std::true_type is_channel_decl_impl(const channel_decl<Ts...>*);
+
+   std::false_type is_channel_decl_impl(...);
+
+   template <typename T>
+   using is_channel_decl = decltype(is_channel_decl_impl(std::declval<T*>()));
+}
+
+#pragma pop_macro("N")

--- a/include/appbase/method.hpp
+++ b/include/appbase/method.hpp
@@ -11,24 +11,30 @@ namespace appbase {
 
    using erased_method_ptr = std::unique_ptr<void, void(*)(void*)>;
 
-   template<typename Ret, typename ... Args>
-   struct dispatch_policy_helper_impl {
-      using result_type = Ret;
-   };
+   namespace impl {
+      template<typename Ret, typename ... Args>
+      struct dispatch_policy_helper_impl {
+         using result_type = Ret;
+      };
 
-   template<typename FunctionSig>
-   struct method_traits;
+      template<typename FunctionSig>
+      struct method_traits;
 
-   template<typename Ret, typename ...Args>
-   struct method_traits<Ret(Args...)> {
-      using result_type = typename dispatch_policy_helper_impl<Ret, Args...>::result_type;
-      using args_tuple_type = std::tuple<Args...>;
+      template<typename Ret, typename ...Args>
+      struct method_traits<Ret(Args...)> {
+         using result_type = typename dispatch_policy_helper_impl<Ret, Args...>::result_type;
+         using args_tuple_type = std::tuple<Args...>;
 
-   };
+      };
+   }
 
+   /**
+    * Basic DispatchPolicy that will try providers sequentially until one succeeds
+    * without throwing an exception.  that result becomes the result of the method
+    */
    template<typename FunctionSig>
    struct first_success_policy {
-      using result_type = typename method_traits<FunctionSig>::result_type;
+      using result_type = typename impl::method_traits<FunctionSig>::result_type;
       std::string err;
 
       /**
@@ -74,9 +80,55 @@ namespace appbase {
    template<typename FunctionSig, typename DispatchPolicy>
    class method final {
       public:
-         using traits = method_traits<FunctionSig>;
+         using traits = impl::method_traits<FunctionSig>;
          using args_tuple_type = typename traits::args_tuple_type;
          using result_type = typename traits::result_type;
+
+         /**
+          * Type that represents a registered provider for a method allowing
+          * for ownership via RAII and also explicit unregistered actions
+          */
+         class handle {
+            public:
+               ~handle() {
+                  unregister();
+               }
+
+               /**
+                * Explicitly unregister a provider for this channel
+                * of this object expires
+                */
+               void unregister() {
+                  if (_handle.connected()) {
+                     _handle.disconnect();
+                  }
+               }
+
+               // This handle can be constructed and moved
+               handle() = default;
+               handle(handle&&) = default;
+               handle& operator= (handle&& rhs) = default;
+
+               // dont allow copying since this protects the resource
+               handle(const handle& ) = delete;
+               handle& operator= (const handle& ) = delete;
+
+            private:
+               using handle_type = boost::signals2::connection;
+               handle_type _handle;
+
+               /**
+                * Construct a handle from an internal represenation of a handle
+                * In this case a boost::signals2::connection
+                *
+                * @param _handle - the boost::signals2::connection to wrap
+                */
+               handle(handle_type&& _handle)
+               :_handle(std::move(_handle))
+               {}
+
+               friend class method;
+         };
 
          /**
           * Register a provider of this method
@@ -86,8 +138,8 @@ namespace appbase {
           * @param priority - the priority of this provider, lower is called before higher
           */
          template<typename T>
-         void register_provider(T provider, int priority = 0) {
-            _signal.connect(priority, provider);
+         handle register_provider(T provider, int priority = 0) {
+            return handle(_signal.connect(priority, provider));
          }
 
          /**
@@ -140,6 +192,12 @@ namespace appbase {
    };
 
 
+   /**
+    *
+    * @tparam Tag - API specific discriminator used to distinguish between otherwise identical method signatures
+    * @tparam FunctionSig - the signature of the method
+    * @tparam DispatchPolicy - dispatch policy that dictates how providers for a method are accessed defaults to @ref first_success_policy
+    */
    template< typename Tag, typename FunctionSig, typename DispatchPolicy = first_success_policy<FunctionSig>>
    struct method_decl {
       using method_type = method<FunctionSig, DispatchPolicy>;

--- a/include/appbase/method.hpp
+++ b/include/appbase/method.hpp
@@ -1,0 +1,157 @@
+#pragma once
+
+//clashes with BOOST PP and Some Applications
+#pragma push_macro("N")
+#undef N
+
+#include <boost/signals2.hpp>
+#include <boost/exception/diagnostic_information.hpp>
+
+namespace appbase {
+
+   using erased_method_ptr = std::unique_ptr<void, void(*)(void*)>;
+
+   template<typename Ret, typename ... Args>
+   struct dispatch_policy_helper_impl {
+      using result_type = Ret;
+   };
+
+   template<typename T>
+   struct function_sig_helper;
+
+   template<typename Ret, typename ...Args>
+   struct function_sig_helper<Ret(Args...)> {
+      using result_type = typename dispatch_policy_helper_impl<Ret, Args...>::result_type;
+      using args_tuple_type = std::tuple<Args...>;
+   };
+
+   template<typename FunctionSig>
+   struct first_success_policy {
+      using result_type = typename function_sig_helper<FunctionSig>::result_type;
+      std::string err;
+
+      /**
+       * Iterate through the providers, calling (dereferencing) each
+       * if the provider throws, then store then try the next provider
+       * if none succeed throw an error with the aggregated error descriptions
+       *
+       * @tparam InputIterator
+       * @param first
+       * @param last
+       * @return
+       */
+      template<typename InputIterator>
+      result_type operator()(InputIterator first, InputIterator last) {
+         while (first != last) {
+            try {
+               return *first; // de-referencing the iterator causes the provider to run
+            } catch (...) {
+               if (!err.empty()) {
+                  err += "\",\"";
+               }
+
+               err += boost::current_exception_diagnostic_information();
+            }
+
+            ++first;
+         }
+
+         throw new std::length_error(std::string("No Result Available, All providers returned exceptions[") + err + "]");
+      }
+   };
+
+   /**
+    * A method is a loosely linked application level function.
+    * Callers can grab a method and call it
+    * Providers can grab a method and register themselves
+    *
+    * This removes the need to tightly couple different plugins in the application.
+    *
+    * @tparam FunctionSig - the signature of the method (eg void(int, int))
+    * @tparam DispatchPolicy - the policy for dispatching this method
+    */
+   template<typename FunctionSig, typename DispatchPolicy>
+   class method final : private boost::signals2::signal<FunctionSig, DispatchPolicy> {
+      public:
+         using args_tuple_type = typename function_sig_helper<FunctionSig>::args_tuple_type;
+         using result_type = typename function_sig_helper<FunctionSig>::result_type;
+
+         /**
+          * Register a provider of this method
+          *
+          * @tparam T - the type of the provider (functor, lambda)
+          * @param provider - the provider
+          * @param priority - the priority of this provider, lower is called before higher
+          */
+         template<typename T>
+         void register_provider(T provider, int priority = 0) {
+            this->connect(priority, provider);
+         }
+
+         /**
+          * inhereted call operator from boost::signals2
+          *
+          * @throws exception depending on the DispatchPolicy
+          */
+         template<typename ... Args>
+         auto operator()(Args ... args) -> typename std::enable_if_t<std::is_same<std::tuple<Args...>, args_tuple_type>::value, result_type>
+         {
+            return this->operator()(args...);
+         }
+
+      protected:
+         method() = default;
+         virtual ~method() {};
+
+         /**
+          * Proper deleter for type-erased method
+          * note: no type checking is performed at this level
+          *
+          * @param erased_method_ptr
+          */
+         static void deleter(void* erased_method_ptr) {
+            method *ptr = reinterpret_cast<method*>(erased_method_ptr);
+            delete ptr;
+         }
+
+         /**
+          * get the method* back from an erased pointer
+          *
+          * @param ptr - the type-erased method pointer
+          * @return - the type safe method pointer
+          */
+         static method* get_method(erased_method_ptr& ptr) {
+            return reinterpret_cast<method*>(ptr.get());
+         }
+
+         /**
+          * Construct a unique_ptr for the type erased method poiner
+          * @return
+          */
+         static erased_method_ptr make_unique() {
+            return erased_method_ptr(new method(), &deleter);
+         }
+
+         friend class appbase::application;
+   };
+
+
+   template< typename Tag, typename FunctionSig, typename DispatchPolicy = first_success_policy<FunctionSig> >
+   struct method_decl {
+      using method_type = method<FunctionSig, DispatchPolicy>;
+      using tag_type = Tag;
+   };
+
+   template <typename...Ts>
+   std::true_type is_method_decl_impl(const method_decl<Ts...>*);
+
+   std::false_type is_method_decl_impl(...);
+
+   template <typename T>
+   using is_method_decl = decltype(is_method_decl_impl(std::declval<T*>()));
+
+
+}
+
+#pragma pop_macro("N")
+

--- a/include/appbase/method.hpp
+++ b/include/appbase/method.hpp
@@ -75,8 +75,8 @@ namespace appbase {
    class method final {
       public:
          using traits = method_traits<FunctionSig>;
-         using args_tuple_type = traits::args_tuple_type;
-         using result_type = traits::result_type;
+         using args_tuple_type = typename traits::args_tuple_type;
+         using result_type = typename traits::result_type;
 
          /**
           * Register a provider of this method
@@ -98,7 +98,7 @@ namespace appbase {
          template<typename ... Args>
          auto operator()(Args&&... args) -> typename std::enable_if_t<std::is_same<std::tuple<Args...>, args_tuple_type>::value, result_type>
          {
-            return _signal(std::forward<Args>(args...));
+            return _signal(std::forward<Args>(args)...);
          }
 
       protected:


### PR DESCRIPTION
This PR adds the concept of Channels and Methods to appbase.

## Channels

Channels are a means to publish data from one plugin that is consumed by many plugins without having to tightly couple the publisher plugin to the consumer plugin.  This is a generic utility that encapsulates a common use case we were seeing in appbase applications where one plugin would directly expose boost signals for other plugins to subscribe to.

```
struct foo {
   int bar; 
};
using foo_channel_decl = channel_decl<struct my_tag, foo>;

// subscribe
auto subscription = app().get_channel<foo_channel_decl>().subscribe([](const foo& f){
   std::cout << "bar: " << f.bar << std::endl;
});

// send some foos
auto& foo_channel = app().get_channel<foo_channel_decl>();
foo_channel.publish(foo{5});  /// prints "bar: 5"
foo_channel.publish(foo{9});  /// prints "bar: 9"

```


## Methods

Methods are a means to fetch values from or run a given command on provider plugin(s) without having to tightly couple the calling plugin to the provider plugin.  

```
using add_method_decl = method_decl(struct my_tag, double(double,double));

// provide
auto provider = app().get_method<add_method_decl>().register_provider([](double a, double b) -> double {
   return a + b;
});

// call the method
double res;
auto& add_method = app().get_method<add_method_decl>();
res = add_method(1.0, 2.0);  /// res ~== 3.0
res = add_method(5.0, 4.0); /// res ~== 9.0
```