### PR TITLE
Include GNUInstallDirs for CMAKE_INSTALL_FULL_*.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ if( APPLE )
 else( APPLE )
   # Linux Specific Options Here
   message( STATUS "Configuring AppBase on Linux" )
+  include( GNUInstallDirs )
   set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++14 -Wall" )
   set( rt_library rt )
   set( pthread_library pthread)


### PR DESCRIPTION
cmake fails on `#1 SMP Debian 4.9.30-2+deb9u5 ` with cmake `version 3.7.2`, showing:
```
CMake Error at CMakeLists.txt:59 (install):
  install TARGETS given no ARCHIVE DESTINATION for static library target
  "appbase".
```

Need to include `GNUInstallDirs` for use of CMAKE_INSTALL__FULL_*.