### PR TITLE
Provide a version string based off "git describe"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 
 add_library( appbase
              application.cpp
+             version.cpp
              ${HEADERS}
            )
 
@@ -53,6 +54,16 @@ target_include_directories( appbase
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR})
 
 set_target_properties( appbase PROPERTIES PUBLIC_HEADER "${HEADERS}" )
+
+find_package(Git)
+if(EXISTS ${CMAKE_SOURCE_DIR}/.git AND GIT_FOUND)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/version.cmake @ONLY)
+  add_custom_target(appbase_version ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/version.cmake BYPRODUCTS version.cpp)
+  add_dependencies(appbase appbase_version)
+else()
+  set(VERSION_STRING "Unknown")
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY ESCAPE_QUOTES)
+endif()
 
 set(CPACK_PACKAGING_INSTALL_PREFIX /)
 

--- a/application.cpp
+++ b/application.cpp
@@ -1,4 +1,5 @@
 #include <appbase/application.hpp>
+#include <appbase/version.hpp>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
@@ -43,6 +44,10 @@ void application::set_version(uint64_t version) {
 
 uint64_t application::version() const {
   return my->_version;
+}
+
+string application::version_string() const {
+   return appbase_version_string;
 }
 
 void application::set_default_data_dir(const bfs::path& data_dir) {
@@ -119,7 +124,7 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
    }
 
    if( options.count( "version" ) ) {
-      cout << my->_version << std::endl;
+      cout << version_string() << std::endl;
       return false;
    }
 

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -26,6 +26,11 @@ namespace appbase {
           * @return Version output with -v/--version
           */
          uint64_t version() const;
+         /** @brief Get version string; generated from git describe if available
+          *
+          * @return A string worthy of output with -v/--version, or "Unknown" if git not available
+          */
+         string version_string() const;
          /** @brief Set default data directory
           *
           * @param data_dir Default data directory to use if not specified

--- a/include/appbase/version.hpp
+++ b/include/appbase/version.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace appbase {
+   extern const char* appbase_version_string;
+}

--- a/version.cmake.in
+++ b/version.cmake.in
@@ -1,0 +1,18 @@
+#performed in a small separate "cmake script" so can easily run on each build
+
+execute_process(
+   COMMAND @GIT_EXECUTABLE@ describe --tags --dirty
+   OUTPUT_VARIABLE VERSION_STRING
+   OUTPUT_STRIP_TRAILING_WHITESPACE
+   RESULT_VARIABLE res
+   WORKING_DIRECTORY @CMAKE_SOURCE_DIR@
+)
+if(NOT ${res} STREQUAL "0")
+  message(FATAL_ERROR "git describe failed")
+endif()
+#unsure if this next is possible but just a failsafe
+if("${VERSION_STRING}" STREQUAL "")
+  set(VERSION_STRING "unknown")
+endif()
+
+configure_file(@CMAKE_CURRENT_SOURCE_DIR@/version.cpp.in @CMAKE_CURRENT_BINARY_DIR@/version.cpp @ONLY ESCAPE_QUOTES)

--- a/version.cpp.in
+++ b/version.cpp.in
@@ -1,0 +1,3 @@
+namespace appbase {
+   const char* appbase_version_string = "@VERSION_STRING@";
+}


### PR DESCRIPTION
Appbase will now provide a version string that is based off "git describe --tags --dirty". This provides a readable version number like v1.1.0 as well as information on intermediate git revisions and/or dirtiness. Since we don’t provide eosio as a .tar.gz package due to Github’s lack of submodules on tarballing, generally all users should be building in a git clone.

Be aware this change will run git describe on EVERY build. The command is quite fast (around 100ms even on a slower 2017 MacBook) and will hopefully provide enough benefit to be worth it.

Note that taking EOSIO/binaryen#12 is required for this to not choke our current buildkite environment.