### PR TITLE
Three improvements to config.ini handling

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -123,7 +123,7 @@ application& application::instance() {
 }
 application& app() { return application::instance(); }
 
-void application::register_config_type_comparision(std::type_index i, config_comparison_f comp) {
+void application::register_config_type_comparison(std::type_index i, config_comparison_f comp) {
    my->_any_compare_map.emplace(i, comp);
 }
 

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -99,11 +99,11 @@ namespace appbase {
           * application.cpp. Failure to register a type will cause initialization to fail.
           */
          template <typename T> void register_config_type() {
-            register_config_type_comparision(typeid(T), [](const auto& a, const auto& b) {
+            register_config_type_comparison(typeid(T), [](const auto& a, const auto& b) {
                return boost::any_cast<const T&>(a) == boost::any_cast<const T&>(b);
             });
          }
-         void register_config_type_comparision(std::type_index, config_comparison_f comp);
+         void register_config_type_comparison(std::type_index, config_comparison_f comp);
 
          static application&  instance();
 

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -10,6 +10,8 @@ namespace appbase {
    namespace bpo = boost::program_options;
    namespace bfs = boost::filesystem;
 
+   using config_comparison_f = std::function<bool(const boost::any& a, const boost::any& b)>;
+
    class application
    {
       public:
@@ -91,6 +93,17 @@ namespace appbase {
           * @return true if quit() has been called.
           */
          bool                 is_quiting()const;
+
+         /**
+          * Register a configuration type with appbase. most "plain" types are already registered in
+          * application.cpp. Failure to register a type will cause initialization to fail.
+          */
+         template <typename T> void register_config_type() {
+            register_config_type_comparision(typeid(T), [](const auto& a, const auto& b) {
+               return boost::any_cast<const T&>(a) == boost::any_cast<const T&>(b);
+            });
+         }
+         void register_config_type_comparision(std::type_index, config_comparison_f comp);
 
          static application&  instance();
 


### PR DESCRIPTION
This PR centers around removing default values from being baked in to the config.ini. The reason this is bad is because, for example, if we want to change the default `bnet-peer-log-format` in the future. If we change the "default" in the code, any users who have a previous config.ini (everyone) won't consume the new default _even if they never overrode the previous default themselves_.

The three changes made are:

* Default values are commented out in the config.ini generation.
* Print a warning about configuration items in config.ini that redundantly set the config to its default. This is to encourage “upgrades” to the new style of config.ini mentioned above where defaults are commented out by default
* A bool (not bool_switch) configuration item is now written as false/true to config.ini instead of 0/1

Appbase needs to know each type it will encounter in the configurations in order to do the comparison to the default. Most plain types like strings, ints, etc are registered by default. Custom types (like an enumeration) must be registered manually by a plugin in its ctor. appbase will now fail to initialize unless all types are registered.

Example output (near exhaustive example):
```
$ programs/nodeos/nodeos -d ~/eos.data/mahnode --config-dir ~/eos.data/mahnode
APPBASE: Warning: The following configuration items in the config.ini file are redundantly set to
         their default value:
             bnet-peer-log-format, blocks-dir, chain-state-db-size-mb, reversible-blocks-db-size-mb, 
             contracts-console, https-client-validate-peers, access-control-allow-credentials, 
             verbose-http-errors, max-login-requests, max-login-timeout, p2p-listen-endpoint, 
             p2p-max-nodes-per-host, agent-name, allowed-connection, max-clients, connection-cleanup-period, 
             network-version-match, sync-fetch-span, max-implicit-request, use-socket-read-watermark, 
             peer-log-format, enable-stale-production, pause-on-startup, max-transaction-time, 
             max-irreversible-block-age, signature-provider, keosd-provider-timeout, 
             txn-reference-block-lag
         Explicit values will override future changes to application defaults. Consider commenting out or
         removing these items.
```