### PR TITLE
Async plugin startup

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -92,13 +92,8 @@ void application::startup() {
       sig_thread.detach();
 
       for( auto plugin : initialized_plugins ) {
-         try {
-            if( is_quiting() ) return;
-            plugin->startup();
-         } catch( ... ) {
-            shutdown();
-            throw;
-         }
+         if( is_quiting() ) return;
+         plugin->startup();
       }
 
    } catch( ... ) {

--- a/application.cpp
+++ b/application.cpp
@@ -28,7 +28,9 @@ class application_impl {
       bfs::path               _logging_conf{"logging.json"};
       bfs::path               _config_file_name;
 
-      uint64_t                _version;
+      uint64_t                _version = 0;
+
+      std::atomic_bool        _is_quiting{false};
 };
 
 application::application()
@@ -64,8 +66,19 @@ bfs::path application::get_logging_conf() const {
 
 void application::startup() {
    try {
-      for (auto plugin : initialized_plugins)
-         plugin->startup();
+      auto ioc = io_serv;
+      for (auto plugin : initialized_plugins) {
+         // order of execution for single-threaded io_service is order of post
+         io_serv->post( [plugin, ioc, this](){
+            try {
+               if( is_quiting() ) return;
+               plugin->startup();
+            } catch(...) {
+               shutdown();
+               throw;
+            }
+         } );
+      }
    } catch(...) {
       shutdown();
       throw;
@@ -217,27 +230,39 @@ void application::shutdown() {
 }
 
 void application::quit() {
+   my->_is_quiting = true;
    io_serv->stop();
 }
 
+bool application::is_quiting() const {
+   return my->_is_quiting;
+}
+
 void application::exec() {
-   std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*io_serv, SIGINT));
+
+   // setup seperate io_service and thread of signals
+   std::shared_ptr<boost::asio::io_service> sig_io_serv = std::make_shared<boost::asio::io_service>();
+
+   std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*sig_io_serv, SIGINT));
    sigint_set->async_wait([sigint_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigint_set->cancel();
    });
 
-   std::shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*io_serv, SIGTERM));
+   std::shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*sig_io_serv, SIGTERM));
    sigterm_set->async_wait([sigterm_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigterm_set->cancel();
    });
 
-   std::shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*io_serv, SIGPIPE));
+   std::shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*sig_io_serv, SIGPIPE));
    sigpipe_set->async_wait([sigpipe_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigpipe_set->cancel();
    });
+
+   std::thread sig_thread( [sig_io_serv]() { sig_io_serv->run(); } );
+   sig_thread.detach();
 
    io_serv->run();
 

--- a/application.cpp
+++ b/application.cpp
@@ -66,20 +66,21 @@ bfs::path application::get_logging_conf() const {
 
 void application::startup() {
    try {
+
       auto ioc = io_serv;
-      for (auto plugin : initialized_plugins) {
-         // order of execution for single-threaded io_service is order of post
-         io_serv->post( [plugin, ioc, this](){
+      io_serv->post( [ioc, this]() {
+         for( auto plugin : initialized_plugins ) {
             try {
                if( is_quiting() ) return;
                plugin->startup();
-            } catch(...) {
+            } catch( ... ) {
                shutdown();
                throw;
             }
-         } );
-      }
-   } catch(...) {
+         }
+      } );
+
+   } catch( ... ) {
       shutdown();
       throw;
    }

--- a/application.cpp
+++ b/application.cpp
@@ -27,7 +27,9 @@ class application_impl {
       bfs::path               _config_dir{"config-dir"};
       bfs::path               _logging_conf{"logging.json"};
 
-      uint64_t                _version;
+      uint64_t                _version = 0;
+
+      std::atomic_bool        _is_quiting{false};
 };
 
 application::application()
@@ -63,8 +65,19 @@ bfs::path application::get_logging_conf() const {
 
 void application::startup() {
    try {
-      for (auto plugin : initialized_plugins)
-         plugin->startup();
+      auto ioc = io_serv;
+      for (auto plugin : initialized_plugins) {
+         // order of execution for single-threaded io_service is order of post
+         io_serv->post( [plugin, ioc, this](){
+            try {
+               if( is_quiting() ) return;
+               plugin->startup();
+            } catch(...) {
+               shutdown();
+               throw;
+            }
+         } );
+      }
    } catch(...) {
       shutdown();
       throw;
@@ -216,27 +229,39 @@ void application::shutdown() {
 }
 
 void application::quit() {
+   my->_is_quiting = true;
    io_serv->stop();
 }
 
+bool application::is_quiting() const {
+   return my->_is_quiting;
+}
+
 void application::exec() {
-   std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*io_serv, SIGINT));
+
+   // setup seperate io_service and thread of signals
+   std::shared_ptr<boost::asio::io_service> sig_io_serv = std::make_shared<boost::asio::io_service>();
+
+   std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*sig_io_serv, SIGINT));
    sigint_set->async_wait([sigint_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigint_set->cancel();
    });
 
-   std::shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*io_serv, SIGTERM));
+   std::shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*sig_io_serv, SIGTERM));
    sigterm_set->async_wait([sigterm_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigterm_set->cancel();
    });
 
-   std::shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*io_serv, SIGPIPE));
+   std::shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*sig_io_serv, SIGPIPE));
    sigpipe_set->async_wait([sigpipe_set,this](const boost::system::error_code& err, int num) {
      quit();
      sigpipe_set->cancel();
    });
+
+   std::thread sig_thread( [sig_io_serv]() { sig_io_serv->run(); } );
+   sig_thread.detach();
 
    io_serv->run();
 

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -74,10 +74,17 @@ namespace appbase {
          void                  shutdown();
 
          /**
-          *  Wait until quit(), SIGINT or SIGTERM and then shutdown
+          *  Wait until quit(), SIGINT or SIGTERM and then shutdown.
+          *  Should only be executed from one thread.
           */
          void                 exec();
          void                 quit();
+
+         /**
+          * If in long running process this flag can be checked to see if processing should be stoppped.
+          * @return true if quit() has been called.
+          */
+         bool                 is_quiting()const;
 
          static application&  instance();
 
@@ -150,6 +157,10 @@ namespace appbase {
             }
          }
 
+         /**
+          * Do not run io_service in any other threads, as application assumes single-threaded execution in exec().
+          * @return io_serivice of application
+          */
          boost::asio::io_service& get_io_service() { return *io_serv; }
       protected:
          template<typename Impl>

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -80,10 +80,17 @@ namespace appbase {
          void                  shutdown();
 
          /**
-          *  Wait until quit(), SIGINT or SIGTERM and then shutdown
+          *  Wait until quit(), SIGINT or SIGTERM and then shutdown.
+          *  Should only be executed from one thread.
           */
          void                 exec();
          void                 quit();
+
+         /**
+          * If in long running process this flag can be checked to see if processing should be stoppped.
+          * @return true if quit() has been called.
+          */
+         bool                 is_quiting()const;
 
          static application&  instance();
 
@@ -156,6 +163,10 @@ namespace appbase {
             }
          }
 
+         /**
+          * Do not run io_service in any other threads, as application assumes single-threaded execution in exec().
+          * @return io_serivice of application
+          */
          boost::asio::io_service& get_io_service() { return *io_serv; }
       protected:
          template<typename Impl>


### PR DESCRIPTION
- add signal handling thread so startup is interruptable
- move setup of signal handling from `exec()` to `startup()` so that plugin startups are interruptable.
