### PR TITLE
Fix appbase cmake rules when used standalone (outside eosio)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Defines AppBase library target.
+cmake_minimum_required( VERSION 3.4 )
 project( AppBase )
-cmake_minimum_required( VERSION 2.8.12 )
+
+include( GNUInstallDirs )
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
@@ -8,7 +10,6 @@ include( InstallDirectoryPermissions )
 
 file(GLOB HEADERS "include/appbase/*.hpp")
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 set(BOOST_COMPONENTS)
 list(APPEND BOOST_COMPONENTS thread
                              date_time
@@ -25,22 +26,13 @@ set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 if( APPLE )
   # Apple Specific Options Here
   message( STATUS "Configuring AppBase on OS X" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++14 -stdlib=libc++ -Wall -Wno-conversion -Wno-deprecated-declarations" )
 else( APPLE )
   # Linux Specific Options Here
   message( STATUS "Configuring AppBase on Linux" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++14 -Wall" )
-  set( rt_library rt )
-  set( pthread_library pthread)
   if ( FULL_STATIC_BUILD )
     set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
   endif ( FULL_STATIC_BUILD )
 endif( APPLE )
-
-
-if(ENABLE_COVERAGE_TESTING)
-    SET(CMAKE_CXX_FLAGS "--coverage ${CMAKE_CXX_FLAGS}")
-endif()
 
 add_library( appbase
              application.cpp
@@ -53,7 +45,12 @@ target_link_libraries( appbase ${Boost_LIBRARIES})
 target_include_directories( appbase
                             PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR})
 
-set_target_properties( appbase PROPERTIES PUBLIC_HEADER "${HEADERS}" )
+set_target_properties( appbase PROPERTIES PUBLIC_HEADER "${HEADERS}" CXX_STANDARD 14 CXX_EXTENSIONS OFF )
+
+target_compile_options( appbase PRIVATE -Wall -Wno-conversion -Wno-deprecated-declarations )
+if(ENABLE_COVERAGE_TESTING)
+    target_compile_options( appbase PRIVATE "--coverage ${CMAKE_CXX_FLAGS}" )
+endif()
 
 find_package(Git)
 if(EXISTS ${CMAKE_SOURCE_DIR}/.git AND GIT_FOUND)
@@ -63,6 +60,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.git AND GIT_FOUND)
 else()
   set(VERSION_STRING "Unknown")
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/version.cpp.in ${CMAKE_CURRENT_BINARY_DIR}/version.cpp @ONLY ESCAPE_QUOTES)
+  set_source_files_properties(version.cpp PROPERTIES GENERATED TRUE)
 endif()
 
 set(CPACK_PACKAGING_INSTALL_PREFIX /)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_executable( appbase_example main.cpp )
 target_link_libraries( appbase_example appbase ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+set_target_properties( appbase_example PROPERTIES CXX_STANDARD 14 CXX_EXTENSIONS OFF )


### PR DESCRIPTION
Two main fixes here: 1) fix build when source is not part of git; 2) include GNUInstallDirs since that is used

A few other minor tweaks as well.

Work on EOSIO/eos#6381