### PR TITLE
Protect quit

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -249,6 +249,7 @@ void application::shutdown() {
 void application::quit() {
    my->_is_quiting = true;
    io_serv->stop();
+   boost::asio::post(*io_serv, [io_service = io_serv]() {} ); // keep io_serv alive until stopped
 }
 
 bool application::is_quiting() const {


### PR DESCRIPTION
- Needed for https://github.com/EOSIO/eos/pull/6471
- Prevent application quit from killing `io_serv` shared_ptr until all posted jobs are done. Since the `io_serv` (`io_context`) is running on only one thread, the `post` with the `io_serv` after `stop` will keep the `io_serv` shared_ptr alive until all other posted jobs are complete or canceled.