### PR TITLE
git describe can fail when fc is a submodule

### DIFF
--- a/version.cmake.in
+++ b/version.cmake.in
@@ -8,7 +8,7 @@ execute_process(
    WORKING_DIRECTORY @CMAKE_SOURCE_DIR@
 )
 if(NOT ${res} STREQUAL "0")
-  message(FATAL_ERROR "git describe failed")
+  set(VERSION_STRING "unknown")
 endif()
 #unsure if this next is possible but just a failsafe
 if("${VERSION_STRING}" STREQUAL "")


### PR DESCRIPTION
When fc is brought in as a submodule, this can happen:

```
appbase$ git describe --tags --dirty
fatal: No names found, cannot describe anything.
```
