### PR TITLE
Block (queue) exit signals during shutdown

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <fstream>
 #include <unordered_map>
+#include <future>
 
 namespace appbase {
 
@@ -85,32 +86,21 @@ bfs::path application::get_logging_conf() const {
 
 void application::startup() {
    try {
+      std::promise<void> sig_thread_ready;
 
-      // setup seperate io_service and thread of signals
-      std::shared_ptr<boost::asio::io_service> sig_io_serv = std::make_shared<boost::asio::io_service>();
-
-      std::shared_ptr<boost::asio::signal_set> sigint_set(new boost::asio::signal_set(*sig_io_serv, SIGINT));
-      sigint_set->async_wait([sigint_set,this](const boost::system::error_code& /*err*/, int /*num*/) {
-         quit();
-         sigint_set->cancel();
+      std::thread sig_thread([&sig_thread_ready, this]() {
+         boost::asio::io_service sig_ios;
+         boost::asio::io_service::work work(sig_ios);
+         boost::asio::signal_set sig_set(sig_ios, SIGINT, SIGTERM, SIGPIPE);
+         sig_thread_ready.set_value();
+         sig_set.async_wait([this](const boost::system::error_code&, int) {
+            quit();
+         });
+         sig_ios.run();
       });
-
-      std::shared_ptr<boost::asio::signal_set> sigterm_set(new boost::asio::signal_set(*sig_io_serv, SIGTERM));
-      sigterm_set->async_wait([sigterm_set,this](const boost::system::error_code& /*err*/, int /*num*/) {
-         quit();
-         sigterm_set->cancel();
-      });
-
-      std::shared_ptr<boost::asio::signal_set> sigpipe_set(new boost::asio::signal_set(*sig_io_serv, SIGPIPE));
-      sigpipe_set->async_wait([sigpipe_set,this](const boost::system::error_code& /*err*/, int /*num*/) {
-         quit();
-         sigpipe_set->cancel();
-      });
-
-      start_sighup_handler();
-
-      std::thread sig_thread( [sig_io_serv]() { sig_io_serv->run(); } );
       sig_thread.detach();
+
+      sig_thread_ready.get_future().wait();
 
       for( auto plugin : initialized_plugins ) {
          if( is_quiting() ) return;


### PR DESCRIPTION
When a shutdown signal is handled the sig_set is 1) canceled and 2) destroyed. This means that signals are no longer handled by boost::asio and revert back to default behavior. If someone accidentally hits ctrl-c a second time during a long shutdown they run the risk of leaving the database dirty as that second ctrl-c will be insta-kill.

This patch changes the behavior and keeps the sig_set active forever. This means that even after the first handled async_wait() on the sig_set (that starts an appbase quit), additional signals in the set are effectively “blocked” (not posix blocked, but blocked in the sense they are consumed and queued by the sig_set that is not being async_wait()ed on)

This is also a possible candidate for 1.7, looking for opinions there.