### PR TITLE
Add description to priority queue

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -329,12 +329,12 @@ bool application::is_quiting() const {
    return my->_is_quiting;
 }
 
-auto log_time( const string& d, long long b, int priority) {
+auto log_time( const string& desc, long long start, int priority) {
    namespace bc = boost::chrono;
    auto now = bc::duration_cast<bc::microseconds>( bc::system_clock::now().time_since_epoch() ).count();
-   auto time = now - b;
-   if( time > 5000 && b != 0) {
-      std::cerr << time << ' ' << d << " p: " << priority << std::endl;
+   auto time = now - start;
+   if( time > 5000 && start != 0) {
+      std::cerr << time << ' ' << desc << " p: " << priority << std::endl;
    }
    return bc::duration_cast<bc::microseconds>( bc::system_clock::now().time_since_epoch() ).count();
 }
@@ -346,11 +346,12 @@ void application::exec() {
    int priority = 0;
    string desc;
    while( more || io_serv->run_one() ) {
-      auto now = log_time(desc, 0, 0);
+//      auto now = log_time(desc, 0, 0);
       while( io_serv->poll_one() ) {}
-      now = log_time("poll", now, 0);
-      std::tie(more, priority, desc) = pri_queue.execute_highest();
-      log_time(desc, now, priority);
+//      now = log_time("poll_one", now, 0);
+//      std::tie(more, priority, desc) = pri_queue.execute_highest();
+      std::tie(more, std::ignore, std::ignore) = pri_queue.execute_highest();
+//      log_time(desc, now, priority);
    }
 
    shutdown(); /// perform synchronous shutdown

--- a/application.cpp
+++ b/application.cpp
@@ -118,7 +118,7 @@ void application::startup() {
 void application::start_sighup_handler() {
    std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(*io_serv, SIGHUP));
    sighup_set->async_wait([sighup_set, this](const boost::system::error_code& err, int /*num*/) {
-      app().post(priority::low, [err, this]() {
+      app().post(priority::low, "sighup", [err, this]() {
          if(!err) {
             sighup_callback();
             for( auto plugin : initialized_plugins ) {
@@ -346,11 +346,11 @@ void application::exec() {
    int priority = 0;
    string desc;
    while( more || io_serv->run_one() ) {
-//      auto now = log_time(desc, 0, 0);
+      auto now = log_time(desc, 0, 0);
       while( io_serv->poll_one() ) {}
-//      now = log_time("poll", now, 0);
+      now = log_time("poll", now, 0);
       std::tie(more, priority, desc) = pri_queue.execute_highest();
-//      log_time(desc, now, priority);
+      log_time(desc, now, priority);
    }
 
    shutdown(); /// perform synchronous shutdown

--- a/application.cpp
+++ b/application.cpp
@@ -331,17 +331,17 @@ bool application::is_quiting() const {
 
 //#define APPBASE_LOG_TIME
 #ifdef APPBASE_LOG_TIME
-void log_time( const char* desc, long long& start, int priority ) {
+long long log_time( const char* desc, long long start, int priority ) {
    namespace bc = boost::chrono;
    auto now = bc::duration_cast<bc::microseconds>( bc::system_clock::now().time_since_epoch() ).count();
    auto time = now - start;
    if( time > 5000 && start != 0) {
       std::cerr << time << ' ' << desc << " p: " << priority << std::endl;
    }
-   start = bc::duration_cast<bc::microseconds>( bc::system_clock::now().time_since_epoch() ).count();
+   return bc::duration_cast<bc::microseconds>( bc::system_clock::now().time_since_epoch() ).count();
 }
 #else
-void log_time( const char*, long long&, int ) {}
+long long log_time( const char*, long long, int ) {}
 #endif
 
 void application::exec() {
@@ -350,11 +350,10 @@ void application::exec() {
    bool more = true;
    int priority = 0;
    string desc;
-   long long start_time = 0;
    while( more || io_serv->run_one() ) {
-      log_time("", start_time, 0);
+      long long start_time = log_time("", 0, 0);
       while( io_serv->poll_one() ) {}
-      log_time("poll_one", start_time, 0);
+      start_time = log_time("poll_one", start_time, 0);
       std::tie(more, priority, desc) = pri_queue.execute_highest();
       log_time(desc.c_str(), start_time, priority);
    }

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -202,8 +202,8 @@ namespace appbase {
           * @return result of boost::asio::post
           */
          template <typename Func>
-         auto post( int priority, string desc, Func&& func ) {
-            return boost::asio::post(*io_serv, pri_queue.wrap(priority, std::move(desc), std::forward<Func>(func)));
+         auto post( int priority, const string& desc, Func&& func ) {
+            return boost::asio::post(*io_serv, pri_queue.wrap(priority, desc, std::forward<Func>(func)));
          }
 
          /**

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -197,12 +197,13 @@ namespace appbase {
           * Post func to run on io_service with given priority.
           *
           * @param priority can be appbase::priority::* constants or any int, larger ints run first
+          * @param desc description of task for debugging
           * @param func function to run on io_service
           * @return result of boost::asio::post
           */
          template <typename Func>
-         auto post( int priority, Func&& func ) {
-            return boost::asio::post(*io_serv, pri_queue.wrap(priority, std::forward<Func>(func)));
+         auto post( int priority, string desc, Func&& func ) {
+            return boost::asio::post(*io_serv, pri_queue.wrap(priority, std::move(desc), std::forward<Func>(func)));
          }
 
          /**
@@ -312,7 +313,7 @@ namespace appbase {
    void channel<Data,DispatchPolicy>::publish(int priority, const Data& data) {
       if (has_subscribers()) {
          // this will copy data into the lambda
-         app().post( priority, [this, data]() {
+         app().post( priority, "channel publish", [this, data]() {
             _signal(data);
          });
       }

--- a/include/appbase/execution_priority_queue.hpp
+++ b/include/appbase/execution_priority_queue.hpp
@@ -51,8 +51,8 @@ public:
    class executor
    {
    public:
-      executor(execution_priority_queue& q, int p, string desc)
-            : context_(q), priority_(p), desc_( std::move(desc) )
+      executor(execution_priority_queue& q, int p, const string& desc)
+            : context_(q), priority_(p), desc_( desc )
       {
       }
 
@@ -100,9 +100,9 @@ public:
 
    template <typename Function>
    boost::asio::executor_binder<Function, executor>
-   wrap(int priority, string desc, Function&& func)
+   wrap(int priority, const string& desc, Function&& func)
    {
-      return boost::asio::bind_executor( executor(*this, priority, std::move( desc) ), std::forward<Function>(func) );
+      return boost::asio::bind_executor( executor( *this, priority, desc ), std::forward<Function>(func) );
    }
 
 private:

--- a/include/appbase/execution_priority_queue.hpp
+++ b/include/appbase/execution_priority_queue.hpp
@@ -45,7 +45,7 @@ public:
          handlers_.pop();
       }
 
-      return { !handlers_.empty(), priority, std::move( desc ) };
+      return std::tuple<bool, int, string>{ !handlers_.empty(), priority, std::move( desc ) };
    }
 
    class executor


### PR DESCRIPTION
- The idea of this PR is to add some basic time logging of executing tasks of the priority queue. The overhead for the descriptions should be minimal.
- Add a description string to priority queue so that when executing a task from the queue timing can report what task was executed
- Add a #define to enable logging of tasks that take longer than 5000 microseconds
