### PR TITLE
rework blocking (queuing) exit signals during shutdown

### DIFF
--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -248,6 +248,10 @@ namespace appbase {
          void set_program_options();
          void write_default_config(const bfs::path& cfg_file);
          void print_default_config(std::ostream& os);
+
+         void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
+         void setup_signal_handling_on_ios(boost::asio::io_service& ios);
+
          std::unique_ptr<class application_impl> my;
 
    };


### PR DESCRIPTION
The previous fix for blocking signals during shutdown seems to have problems on older platforms/compilers/stdlibs like gcc6. To be completely frank I couldn’t quite pinpoint the exact cause but I highly suspect it is something to do with the `application` instance being static and thus the ordering of static destructors being unfavorable.

I’ve changed the implementation such that during startup a separate thread is run that catches the signals but after startup that thread is retired and signal handling is then handled on the main io_service. Signals end up being blocked (queued) until destruction of application’s io_service because the async_wait() will hold a shared_ptr to the signal_set. The implementation ends up being a bit long winded but means there are no shenanigans trying to clean up threads after main() has fully returned.