### PR TITLE
Use imported targets for boost & other minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,35 +1,37 @@
 # Defines AppBase library target.
 project( AppBase )
-cmake_minimum_required( VERSION 2.8.12 )
+cmake_minimum_required( VERSION 3.5 )
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 include( InstallDirectoryPermissions )
+include( GNUInstallDirs )
 
 file(GLOB HEADERS "include/appbase/*.hpp")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS "ON")
-set(BOOST_COMPONENTS)
-list(APPEND BOOST_COMPONENTS date_time
-                             filesystem
-                             system
-                             chrono
-                             program_options
-                             unit_test_framework)
 
-find_package(Boost 1.60 REQUIRED COMPONENTS ${BOOST_COMPONENTS})
-set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
+if(CMAKE_CXX_STANDARD EQUAL 98 OR CMAKE_CXX_STANDARD LESS 14)
+   message(FATAL_ERROR "appbase requires c++14 or newer")
+elseif(NOT CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 14)
+   set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
+
+find_package(Boost 1.60 REQUIRED COMPONENTS filesystem program_options)
 
 if( APPLE )
   # Apple Specific Options Here
   message( STATUS "Configuring AppBase on OS X" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++14 -stdlib=libc++ -Wall -Wno-conversion -Wno-deprecated-declarations" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-conversion -Wno-deprecated-declarations" )
 else( APPLE )
   # Linux Specific Options Here
   message( STATUS "Configuring AppBase on Linux" )
-  set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -std=c++14 -Wall" )
-  set( rt_library rt )
-  set( pthread_library pthread)
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall" )
   if ( FULL_STATIC_BUILD )
     set( CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
   endif ( FULL_STATIC_BUILD )
@@ -46,10 +48,10 @@ add_library( appbase
              ${HEADERS}
            )
 
-target_link_libraries( appbase ${Boost_LIBRARIES})
+target_link_libraries( appbase Boost::program_options Boost::filesystem Threads::Threads)
 
 target_include_directories( appbase
-                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include" ${Boost_INCLUDE_DIR})
+                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 set_target_properties( appbase PROPERTIES PUBLIC_HEADER "${HEADERS}" )
 


### PR DESCRIPTION
Use boost imported targets so that compiles with boost 1.70 work when using the new cmake config files. Also, change how the c++ standard is getting set so that it’s more modern and also doesn’t stomp on flags. Also, remove the Boost_USE_STATIC_LIBS setting since it was a noop where it was anyways. Add usage of Threads here because in a test I did, just cloning the repo and trying to build it needed it.