### PR TITLE
Setup SIGHUP on startup

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -135,8 +135,10 @@ void application::startup() {
    clean_up_signal_thread();
    setup_signal_handling_on_ios(get_io_service(), false);
 
-   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(*io_serv, SIGHUP));
+#ifdef SIGHUP
+   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(get_io_service(), SIGHUP));
    start_sighup_handler( sighup_set );
+#endif
 }
 
 void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set ) {

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -252,13 +252,13 @@ namespace appbase {
          std::shared_ptr<boost::asio::io_service>  io_serv;
          execution_priority_queue                  pri_queue;
 
-         void start_sighup_handler();
+         void start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set );
          void set_program_options();
          void write_default_config(const bfs::path& cfg_file);
          void print_default_config(std::ostream& os);
 
          void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
-         void setup_signal_handling_on_ios(boost::asio::io_service& ios);
+         void setup_signal_handling_on_ios(boost::asio::io_service& ios, bool startup);
 
          std::unique_ptr<class application_impl> my;
 


### PR DESCRIPTION
- `start_sighup_handler()` was not being called so any registered sighup handler was never called. `SIGHUP` would hangup (terminate) the process.
- Handle SIGHUP same as `SIGINT/SIGTERM/SIGPIPE` on startup (quit the application gracefully).
- After startup call registered sighup on each initialized plugin and re-register `SIGHUP` handling.
- This will allow `nodeos` to update logging on a running instance of `nodeos` via a `SIGHUP`.
  -- Note this requires a nodeos with a thread-safe `fc` logging implementation. Do NOT merge until corresponding `fc` PR is merged. https://github.com/EOSIO/fc/pull/100