### PR TITLE
Setup SIGHUP on startup - v1.7.x

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -93,15 +93,20 @@ void application::wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss) {
    });
 }
 
-void application::setup_signal_handling_on_ios(boost::asio::io_service& ios) {
+void application::setup_signal_handling_on_ios(boost::asio::io_service& ios, bool startup) {
    std::shared_ptr<boost::asio::signal_set> ss = std::make_shared<boost::asio::signal_set>(ios, SIGINT, SIGTERM, SIGPIPE);
+#ifdef SIGHUP
+   if( startup ) {
+      ss->add(SIGHUP);
+   }
+#endif
    wait_for_signal(ss);
 }
 
 void application::startup() {
-   //during startup, run a second thread to catch SIGINT/SIGTERM/SIGPIPE
+   //during startup, run a second thread to catch SIGINT/SIGTERM/SIGPIPE/SIGHUP
    boost::asio::io_service startup_thread_ios;
-   setup_signal_handling_on_ios(startup_thread_ios);
+   setup_signal_handling_on_ios(startup_thread_ios, true);
    std::thread startup_thread([&startup_thread_ios]() {
       startup_thread_ios.run();
    });
@@ -124,23 +129,26 @@ void application::startup() {
 
    //after startup, shut down the signal handling thread and catch the signals back on main io_service
    clean_up_signal_thread();
-   setup_signal_handling_on_ios(get_io_service());
+   setup_signal_handling_on_ios(get_io_service(), false);
+
+   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(*io_serv, SIGHUP));
+   start_sighup_handler( sighup_set );
 }
 
-void application::start_sighup_handler() {
-   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(*io_serv, SIGHUP));
+void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set ) {
+#ifdef SIGHUP
    sighup_set->async_wait([sighup_set, this](const boost::system::error_code& err, int /*num*/) {
-      app().post(priority::low, [err, this]() {
-         if(!err) {
-            sighup_callback();
-            for( auto plugin : initialized_plugins ) {
-               if( is_quiting() ) return;
-               plugin->handle_sighup();
-            }
-            start_sighup_handler();
+      if( err ) return;
+      app().post(priority::medium, [sighup_set, this]() {
+         sighup_callback();
+         for( auto plugin : initialized_plugins ) {
+            if( is_quiting() ) return;
+            plugin->handle_sighup();
          }
       });
+      start_sighup_handler( sighup_set );
    });
+#endif
 }
 
 application& application::instance() {

--- a/application.cpp
+++ b/application.cpp
@@ -131,8 +131,10 @@ void application::startup() {
    clean_up_signal_thread();
    setup_signal_handling_on_ios(get_io_service(), false);
 
-   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(*io_serv, SIGHUP));
+#ifdef SIGHUP
+   std::shared_ptr<boost::asio::signal_set> sighup_set(new boost::asio::signal_set(get_io_service(), SIGHUP));
    start_sighup_handler( sighup_set );
+#endif
 }
 
 void application::start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set ) {

--- a/include/appbase/application.hpp
+++ b/include/appbase/application.hpp
@@ -244,13 +244,13 @@ namespace appbase {
          std::shared_ptr<boost::asio::io_service>  io_serv;
          execution_priority_queue                  pri_queue;
 
-         void start_sighup_handler();
+         void start_sighup_handler( std::shared_ptr<boost::asio::signal_set> sighup_set );
          void set_program_options();
          void write_default_config(const bfs::path& cfg_file);
          void print_default_config(std::ostream& os);
 
          void wait_for_signal(std::shared_ptr<boost::asio::signal_set> ss);
-         void setup_signal_handling_on_ios(boost::asio::io_service& ios);
+         void setup_signal_handling_on_ios(boost::asio::io_service& ios, bool startup);
 
          std::unique_ptr<class application_impl> my;
 


### PR DESCRIPTION
- `start_sighup_handler()` was not being called so any registered sighup handler was never called. `SIGHUP` would hangup (terminate) the process.
- Handle SIGHUP same as `SIGINT/SIGTERM/SIGPIPE` on startup (quit the application gracefully).
- After startup call registered sighup on each initialized plugin and re-register `SIGHUP` handling.
- This will allow `nodeos` to update logging on a running instance of `nodeos` via a `SIGHUP`.
  -- Note this requires a nodeos with a thread-safe `fc` logging implementation. Do NOT merge until corresponding `fc` PR is merged. https://github.com/EOSIO/fc/pull/104