### PR TITLE
disallow "non-options" on the command line from being silently ignored

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -205,7 +205,11 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
 
    bpo::variables_map& options = my->_options;
    try {
-      bpo::store(bpo::parse_command_line(argc, argv, my->_app_options), options);
+      bpo::parsed_options parsed = bpo::command_line_parser(argc, argv).options(my->_app_options).run();
+      bpo::store(parsed, options);
+      vector<string> positionals = bpo::collect_unrecognized(parsed.options, bpo::include_positional);
+      if(!positionals.empty())
+         BOOST_THROW_EXCEPTION(std::runtime_error("Unknown option '" + positionals[0] + "' passed as command line argument"));
    } catch( const boost::program_options::unknown_option& e ) {
       BOOST_THROW_EXCEPTION(std::runtime_error("Unknown option '" + e.get_option_name() + "' passed as command line argument"));
    }


### PR DESCRIPTION
boost program options by default allows what it calls "positional" arguments to be silently collected. The intention would be for, say, someone with a compiler being run as `compiler foo bar -o output` to see that `foo` and `bar` are positional arguments.

But this leads to unexpected behavior in nodeos. Running nodeos as `./nodeos foo bar` gives no errors, even though neither `foo` nor `bar` are valid command line options.

This PR disallows any "positional" argument. Some pretty arcane usage of the nodeos command line does appear to still work. For example `./nodeos -pblah eosio -e` still does produce as eosio. But, `./nodeos -pblah eosio -e foo` is now an error where it wasn't before.