### PR TITLE
config file dir searching

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -207,8 +207,8 @@ void application::set_program_options()
          ("print-default-config", "Print default configuration template")
          ("data-dir,d", bpo::value<std::string>(), "Directory containing program runtime data")
          ("config-dir", bpo::value<std::string>(), "Directory containing configuration files such as config.ini")
-         ("config,c", bpo::value<std::string>()->default_value( "config.ini" ), "Configuration file name, file name only relative to config-dir, or relative path from current dir")
-         ("logconf,l", bpo::value<std::string>()->default_value( "logging.json" ), "Logging configuration file name/path for library users, file name only relative to config-dir, or relative path from current dir");
+         ("config,c", bpo::value<std::string>()->default_value( "config.ini" ), "Configuration file name, filename only default to config-dir, filename with relative path from current dir")
+         ("logconf,l", bpo::value<std::string>()->default_value( "logging.json" ), "Logging configuration file name/path for library users, filename only default to config-dir, filename with relative path from current dir");
 
    my->_cfg_options.add(app_cfg_opts);
    my->_app_options.add(app_cfg_opts);


### PR DESCRIPTION
For issue: https://github.com/EOSIO/eos/issues/8987

Fix:
1. updated the help section for config and logging-config
-c [ --config ] arg (=config.ini) Configuration file name, filename only
default to config-dir, filename with
relative path from current dir
-l [ --logconf ] arg (=logging.json) Logging configuration file name/path
for library users, filename only
default to config-dir, filename with
relative path from current dir

2. filename dir searching logic:
a) filename without relative path (filename only), searching config-dir
b) filename with relative path ("." or "..", searching current/execution dir)
c) no change to filename with absolute path.