### PR TITLE
Fix for empty ("") appbase config default value

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -465,7 +465,7 @@ void application::print_default_config(std::ostream& os) {
          else {
             // The string is formatted "arg (=<interesting part>)"
             example.erase(0, 6);
-            example.erase(example.length()-1);
+            if(!example.empty()) example.erase(example.length()-1);
             os << "# " << od->long_name() << " = " << example << std::endl;
          }
       }


### PR DESCRIPTION
- Specifying an empty "" default value would fail when trying to create a new config.ini file.
  - Example: 
```
void new_plugin::set_program_options(options_description& cli, options_description& cfg) {
   auto op = cfg.add_options();
   op("option-one", bpo::value<std::string>()->default_value(""), "Option");
}

```
