### PR TITLE
fix 'failed to initialize' bug in nodeos

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -363,6 +363,10 @@ bool application::initialize_impl(int argc, char** argv, vector<abstract_plugin*
          if (plugin != nullptr && plugin->get_state() == abstract_plugin::registered)
             plugin->initialize(options);
    } catch (...) {
+      if( options.count("print-build-info") || options.count("print-genesis-json") 
+         || options.count("extract-build-info") || options.count("extract-genesis-json")) {
+         return false;
+      }
       std::cerr << "Failed to initialize\n";
       return false;
    }


### PR DESCRIPTION
When using certain options when launching nodeos, which merely print to console and exit, the user will get a message 'failed to initialize'.   However since initialization is not attempted fully, this is expected behavior, so no error should be reported.