### PR TITLE
Forwarding references for method

### DIFF
--- a/include/appbase/method.hpp
+++ b/include/appbase/method.hpp
@@ -144,17 +144,17 @@ namespace appbase {
             using signal_type = boost::signals2::signal<Ret(Args...), DispatchPolicy>;
             using result_type = Ret;
 
-            method_caller()
-            {}
+            method_caller() = default;
 
             /**
              * call operator from boost::signals2
              *
              * @throws exception depending on the DispatchPolicy
              */
-            Ret operator()(Args&&... args)
+            template<typename ...FuncArgs>
+            Ret operator()(FuncArgs&&... args)
             {
-               return _signal(std::forward<Args>(args)...);
+               return _signal(std::forward<FuncArgs>(args)...);
             }
 
             signal_type _signal;
@@ -166,17 +166,17 @@ namespace appbase {
             using signal_type = boost::signals2::signal<void(Args...), DispatchPolicy>;
             using result_type = void;
 
-            method_caller()
-            {}
+            method_caller() = default;
 
             /**
              * call operator from boost::signals2
              *
              * @throws exception depending on the DispatchPolicy
              */
-            void operator()(Args&&... args)
+            template<typename ...FuncArgs>
+            void operator()(FuncArgs&&... args)
             {
-               _signal(std::forward<Args>(args)...);
+               _signal(std::forward<FuncArgs>(args)...);
             }
 
             signal_type _signal;
@@ -218,8 +218,8 @@ namespace appbase {
 
                // This handle can be constructed and moved
                handle() = default;
-               handle(handle&&) = default;
-               handle& operator= (handle&& rhs) = default;
+               handle(handle&&) noexcept = default;
+               handle& operator= (handle&& rhs) noexcept = default;
 
                // dont allow copying since this protects the resource
                handle(const handle& ) = delete;
@@ -235,7 +235,7 @@ namespace appbase {
                 *
                 * @param _handle - the boost::signals2::connection to wrap
                 */
-               handle(handle_type&& _handle)
+               explicit handle(handle_type&& _handle)
                :_handle(std::move(_handle))
                {}
 

--- a/include/appbase/method.hpp
+++ b/include/appbase/method.hpp
@@ -218,8 +218,8 @@ namespace appbase {
 
                // This handle can be constructed and moved
                handle() = default;
-               handle(handle&&) noexcept = default;
-               handle& operator= (handle&& rhs) noexcept = default;
+               handle(handle&&) = default;
+               handle& operator= (handle&& rhs) = default;
 
                // dont allow copying since this protects the resource
                handle(const handle& ) = delete;


### PR DESCRIPTION
- Forwarding references only work for templated functions not templated classes.
- Includes some misc. cleanup as well: default constructor, explicit constructor